### PR TITLE
Use ActionMailer delivery method settings and add Railtie

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,6 @@ coverage/
 doc/
 docs.zip
 .release/
+
+spec/dummy/log/
+spec/dummy/tmp/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 Unreleased Changes
 ------------------
 
+* Feature - [Major Version] Register ActionMailers with a Railtie and allow for configuration using `config.action_mailer.ses_v2_settings` and `config.action_mailer.ses_settings`.
+
 0.1.0 (2024-11-16)
 ------------------
 

--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ delivery method classes with Amazon SES and SESV2.
 Add this gem to your Rails project's Gemfile:
 
 ```ruby
+gem 'aws-sdk-rails', '~> 4'
 gem 'aws-actionmailer-ses', '~> 0'
 ```
 

--- a/README.md
+++ b/README.md
@@ -13,7 +13,6 @@ delivery method classes with Amazon SES and SESV2.
 Add this gem to your Rails project's Gemfile:
 
 ```ruby
-gem 'aws-sdk-rails', '~> 4'
 gem 'aws-actionmailer-ses', '~> 0'
 ```
 
@@ -34,21 +33,24 @@ check Amazon EC2 instance metadata for credentials to load. Learn more:
 
 ## Usage
 
-To use these mailers as a delivery method, you need to register them with
-`ActionMailer::Base`. You can create a Rails initializer
-`config/initializers/action_mailer.rb` with contents similar to the following:
+To use these mailers as a delivery method, you need to set the delivery method
+and configure the delivery method with the appropriate settings. For example,
+to configure ActionMailer to use the Amazon SESV2 API in the `us-west-2`
+region, you can add the following to an environment file in your Rails
+application:
 
 ```ruby
-options = { region: 'us-west-2' }
-ActionMailer::Base.add_delivery_method :ses, Aws::ActionMailer::SES::Mailer, **options
-ActionMailer::Base.add_delivery_method :ses_v2, Aws::ActionMailer::SESV2::Mailer, **options
-```
+# config/environments/production.rb
 
-In your Rails environment configuration, set the delivery method to
-`:ses` or `:ses_v2`.
+Rails.application.configure do |config|
+  ...
 
-```ruby
-config.action_mailer.delivery_method = :ses # or :ses_v2
+  # Use the Amazon SESV2 API in the us-west-2 region
+  config.action_mailer.delivery_method = :ses_v2
+  config.action_mailer.ses_v2_settings = { region: 'us-west-2' }
+
+  ...
+end
 ```
 
 ## Using ARNs with SES
@@ -59,13 +61,13 @@ to send emails. These operations allows you to specify a cross-account identity
 for the email's Source, From, and Return-Path. To set these ARNs, use any of the
 following headers on your `Mail::Message` object returned by your Mailer class:
 
-* X-SES-SOURCE-ARN
-* X-SES-FROM-ARN
-* X-SES-RETURN-PATH-ARN
+* `X-SES-SOURCE-ARN`
+* `X-SES-FROM-ARN`
+* `X-SES-RETURN-PATH-ARN`
 
 Example:
 
-```
+```ruby
 # in your Rails controller
 message = MyMailer.send_email(options)
 message['X-SES-FROM-ARN'] = 'arn:aws:ses:us-west-2:012345678910:identity/bigchungus@memes.com'

--- a/lib/aws-actionmailer-ses.rb
+++ b/lib/aws-actionmailer-ses.rb
@@ -2,6 +2,7 @@
 
 require_relative 'aws/action_mailer/ses/mailer'
 require_relative 'aws/action_mailer/ses_v2/mailer'
+require_relative 'aws/action_mailer/railtie' if defined?(Rails::Railtie)
 
 module Aws
   module ActionMailer

--- a/lib/aws/action_mailer/railtie.rb
+++ b/lib/aws/action_mailer/railtie.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+module Aws
+  module ActionMailer
+    class Railtie < Rails::Railtie
+      config.before_initialize do
+        ActiveSupport.on_load :action_mailer do
+          add_delivery_method :ses, SES::Mailer
+          add_delivery_method :ses_v2, SESV2::Mailer
+        end
+      end
+    end
+  end
+end

--- a/lib/aws/action_mailer/railtie.rb
+++ b/lib/aws/action_mailer/railtie.rb
@@ -2,9 +2,11 @@
 
 module Aws
   module ActionMailer
+    # Automatically configures ActionMailer to support the Amazon SES and SESV2
+    # delivery methods.
     class Railtie < Rails::Railtie
       config.before_initialize do
-        ActiveSupport.on_load :action_mailer do
+        ActiveSupport.on_load(:action_mailer) do
           add_delivery_method :ses, SES::Mailer
           add_delivery_method :ses_v2, SESV2::Mailer
         end

--- a/lib/aws/action_mailer/ses/mailer.rb
+++ b/lib/aws/action_mailer/ses/mailer.rb
@@ -15,6 +15,8 @@ module Aws
       #
       # @see https://guides.rubyonrails.org/action_mailer_basics.html
       class Mailer
+        attr_reader :settings
+
         # @param [Hash] settings Passes along initialization options to
         #   [Aws::SES::Client.new](https://docs.aws.amazon.com/sdk-for-ruby/v3/api/Aws/SES/Client.html#initialize-instance_method).
         def initialize(settings = {})
@@ -33,11 +35,6 @@ module Aws
           @client.send_raw_email(params).tap do |response|
             message.header[:ses_message_id] = response.message_id
           end
-        end
-
-        # @return [Hash]
-        def settings
-          @settings
         end
       end
     end

--- a/lib/aws/action_mailer/ses/mailer.rb
+++ b/lib/aws/action_mailer/ses/mailer.rb
@@ -7,22 +7,19 @@ module Aws
     module SES
       # Provides a delivery method for ActionMailer that uses Amazon Simple Email Service.
       #
-      # Configure a delivery method with:
-      #
-      #     client_options = { region: 'us-west-2' }
-      #     ActionMailer::Base.add_delivery_method :ses, Aws::ActionMailer::SESMailer, **client_options
-      #
-      # Client options are used to construct a new Aws::SES::Client instance.
+      # Delivery settings are used to construct a new Aws::SES::Client instance.
       # Once you have a delivery method, you can configure your Rails environment to use it:
       #
       #     config.action_mailer.delivery_method = :ses
+      #     config.action_mailer.ses_settings = { region: 'us-west-2' }
       #
       # @see https://guides.rubyonrails.org/action_mailer_basics.html
       class Mailer
-        # @param [Hash] options Passes along initialization options to
+        # @param [Hash] settings Passes along initialization options to
         #   [Aws::SES::Client.new](https://docs.aws.amazon.com/sdk-for-ruby/v3/api/Aws/SES/Client.html#initialize-instance_method).
-        def initialize(options = {})
-          @client = Aws::SES::Client.new(options)
+        def initialize(settings = {})
+          @settings = settings
+          @client = Aws::SES::Client.new(settings)
           @client.config.user_agent_frameworks << 'aws-actionmailer-ses'
         end
 
@@ -40,7 +37,7 @@ module Aws
 
         # @return [Hash]
         def settings
-          {}
+          @settings
         end
       end
     end

--- a/lib/aws/action_mailer/ses_v2/mailer.rb
+++ b/lib/aws/action_mailer/ses_v2/mailer.rb
@@ -15,6 +15,8 @@ module Aws
       #
       # @see https://guides.rubyonrails.org/action_mailer_basics.html
       class Mailer
+        attr_reader :settings
+
         # @param [Hash] settings Passes along initialization settings to
         #   [Aws::SESV2::Client.new](https://docs.aws.amazon.com/sdk-for-ruby/v3/api/Aws/SESV2/Client.html#initialize-instance_method).
         def initialize(settings = {})
@@ -36,11 +38,6 @@ module Aws
           @client.send_email(params).tap do |response|
             message.header[:ses_message_id] = response.message_id
           end
-        end
-
-        # @return [Hash]
-        def settings
-          @settings
         end
 
         private

--- a/lib/aws/action_mailer/ses_v2/mailer.rb
+++ b/lib/aws/action_mailer/ses_v2/mailer.rb
@@ -7,22 +7,19 @@ module Aws
     module SESV2
       # Provides a delivery method for ActionMailer that uses Amazon Simple Email Service V2.
       #
-      # Configure a delivery method with:
-      #
-      #     client_options = { region: 'us-west-2' }
-      #     ActionMailer::Base.add_delivery_method :ses_v2, Aws::ActionMailer::SESV2Mailer, **client_options
-      #
-      # Client options are used to construct a new Aws::SESV2::Client instance.
+      # Delivery settings are used to construct a new Aws::SESV2::Client instance.
       # Once you have a delivery method, you can configure your Rails environment to use it:
       #
       #     config.action_mailer.delivery_method = :ses_v2
+      #     config.action_mailer.ses_v2_settings = { region: 'us-west-2' }
       #
       # @see https://guides.rubyonrails.org/action_mailer_basics.html
       class Mailer
-        # @param [Hash] options Passes along initialization options to
+        # @param [Hash] settings Passes along initialization settings to
         #   [Aws::SESV2::Client.new](https://docs.aws.amazon.com/sdk-for-ruby/v3/api/Aws/SESV2/Client.html#initialize-instance_method).
-        def initialize(options = {})
-          @client = Aws::SESV2::Client.new(options)
+        def initialize(settings = {})
+          @settings = settings
+          @client = Aws::SESV2::Client.new(settings)
           @client.config.user_agent_frameworks << 'aws-actionmailer-ses'
         end
 
@@ -43,7 +40,7 @@ module Aws
 
         # @return [Hash]
         def settings
-          {}
+          @settings
         end
 
         private

--- a/spec/aws/action_mailer/ses/mailer_spec.rb
+++ b/spec/aws/action_mailer/ses/mailer_spec.rb
@@ -33,12 +33,13 @@ module Aws
         end
 
         before do
-          ::ActionMailer::Base.add_delivery_method :ses, Mailer, **client_options
+          ::ActionMailer::Base.add_delivery_method :ses, Mailer
+          ::ActionMailer::Base.ses_settings = client_options
         end
 
         describe '#settings' do
-          it 'returns an empty hash' do
-            expect(mailer.settings).to eq({})
+          it 'returns the client options' do
+            expect(mailer.settings).to eq(client_options)
           end
         end
 

--- a/spec/aws/action_mailer/ses/mailer_spec.rb
+++ b/spec/aws/action_mailer/ses/mailer_spec.rb
@@ -33,7 +33,6 @@ module Aws
         end
 
         before do
-          ::ActionMailer::Base.add_delivery_method :ses, Mailer
           ::ActionMailer::Base.ses_settings = client_options
         end
 

--- a/spec/aws/action_mailer/ses_v2/mailer_spec.rb
+++ b/spec/aws/action_mailer/ses_v2/mailer_spec.rb
@@ -33,7 +33,6 @@ module Aws
         end
 
         before do
-          ::ActionMailer::Base.add_delivery_method :ses_v2, Mailer
           ::ActionMailer::Base.ses_v2_settings = client_options
         end
 

--- a/spec/aws/action_mailer/ses_v2/mailer_spec.rb
+++ b/spec/aws/action_mailer/ses_v2/mailer_spec.rb
@@ -33,12 +33,13 @@ module Aws
         end
 
         before do
-          ::ActionMailer::Base.add_delivery_method :ses_v2, Mailer, **client_options
+          ::ActionMailer::Base.add_delivery_method :ses_v2, Mailer
+          ::ActionMailer::Base.ses_v2_settings = client_options
         end
 
         describe '#settings' do
-          it 'returns an empty hash' do
-            expect(mailer.settings).to eq({})
+          it 'returns the client options' do
+            expect(mailer.settings).to eq(client_options)
           end
         end
 

--- a/spec/dummy/config.ru
+++ b/spec/dummy/config.ru
@@ -1,0 +1,3 @@
+# frozen_string_literal: true
+
+# This file indicates the Rails root directory

--- a/spec/dummy/config/application.rb
+++ b/spec/dummy/config/application.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+require 'rails'
+require 'action_controller/railtie'
+require 'action_mailer/railtie'
+
+require 'aws-actionmailer-ses'
+
+# @api private
+module Dummy
+  class Application < Rails::Application
+    config.load_defaults Rails::VERSION::STRING.to_f
+    config.eager_load = true
+    config.secret_key_base = 'secret'
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,7 +1,16 @@
 # frozen_string_literal: true
 
-require 'action_mailer'
+require 'action_mailer/railtie'
 require 'aws-actionmailer-ses'
+
+# Create a new Rails application to test that the Aws::ActionMailer::Railtie
+# properly initializes the SES and SESV2 ActionMailer delivery methods.
+class TestApp < Rails::Application
+  config.load_defaults Rails::VERSION::STRING.to_f
+  config.eager_load = false
+end
+
+Rails.application.initialize!
 
 class TestMailer < ActionMailer::Base
   layout nil

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,14 +1,8 @@
 # frozen_string_literal: true
 
-require 'action_mailer/railtie'
-require 'aws-actionmailer-ses'
+ENV['RAILS_ENV'] = 'test'
 
-# Create a new Rails application to test that the Aws::ActionMailer::Railtie
-# properly initializes the SES and SESV2 ActionMailer delivery methods.
-class TestApp < Rails::Application
-  config.load_defaults Rails::VERSION::STRING.to_f
-  config.eager_load = false
-end
+require_relative 'dummy/config/application'
 
 Rails.application.initialize!
 


### PR DESCRIPTION
First, I would like to say thanks again for extracting this gem from the `aws-sdk-rails` project and sorry it took me a bit to get around to testing it. So far it looks good, but I think there are a few things we could do to make this integration more seamless and behave a bit more like the built-in `ActionMailer` delivery methods. Would love to get your take on them.

## Reintroduce Railtie

You mentioned in your PR where this gem was extracted that you were removing the automatic registration. What was the rationale for that?

Personally, I think automatic registration via `Railtie` makes sense and is not unexpected in the Rails ecosystem, but we should do it iff Rails is present (the `defined?` clause). I think this is what @ckhsponge was getting at in https://github.com/aws/aws-activejob-sqs-ruby/issues/5.

That said, it would be pretty surprising for someone to use Action Mailer outside of Rails specifically because of how coupled it is to the rest of the Rails subprojects (it has [hard dependencies](https://github.com/rails/rails/blob/main/actionmailer/actionmailer.gemspec#L36-L39) on `activesupport`, `actionpack`, `actionview`, and `activejob`). If someone wanted to use the SES/SESV2 delivery methods with the `mail` gem directly I believe that would still work and maybe we could add something to the README on how to do this.

## `ActionMailer`-style Configuration

The second change, which is why the first change can be made at all, is that we rely on Action Mailer's convention for configuration instead of passing default configuration to the delivery method when it's added. When a delivery method is added to `ActionMailer::Base`, it will [automatically create (and use) a corresponding `#{delivery_method}_settings` class attribute accessor](https://github.com/rails/rails/blob/main/actionmailer/lib/action_mailer/delivery_methods.rb#L52-L53) any time it [delivers mail via that delivery method](https://github.com/rails/rails/blob/main/actionmailer/lib/action_mailer/delivery_methods.rb#L66). This is the same mechanism that the Rails guides outlines in [Action Mailer Basics](https://guides.rubyonrails.org/action_mailer_basics.html#example-action-mailer-configuration) for setting up `sendmail_settings` and `smtp_settings`.

This mechanism allows us to not require any configuration at all in the default case, which is probably what most folks who are using IMDS or application-wide AWS environment variables would have anyway while still allowing additional configuration after the delivery method has been added if necessary.

The one downside, which is not unique to this implementation, but more to ActionMailer configuration generally, is that configuring Action Mailer through the `config.action_mailer` interface as outlined in [Action Mailer Basics](https://guides.rubyonrails.org/action_mailer_basics.html#example-action-mailer-configuration) should (must?) be done in `config/environments/*.rb` rather than `config/initializers` because the Action Mailer initializer that copies the configuration from `config.action_mailer` into `ActionMailer::Base` runs *before* the application's `config/initializers`. 

See the list of initializers in [Configuring Rails Applications](https://guides.rubyonrails.org/configuring.html#initializers), and specifically the ordering of `action_mailer.set_configs` before `load_config_initializers` to understand why this doesn't work.

## Recap

Together, I think the automatic registration of the Railtie plus the configuration via `config.action_mailer.sesv2_settings` makes for a more straight forward and intuitive usage of the library as it matches how existing Action Mailer users are used to configuring their delivery method.

Additionally, if users are already following best practices (using EC2 instance roles, ECS task roles, etc. vs. explicit credentials, cross-region calls, etc.) then the only configuration they need to do is change the `config.action_mailer.delivery_method` to `:ses_v2` and everything "just works".

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license.
