### PR TITLE
Fix settings config loading

### DIFF
--- a/lib/aws/action_mailer/railtie.rb
+++ b/lib/aws/action_mailer/railtie.rb
@@ -2,8 +2,7 @@
 
 module Aws
   module ActionMailer
-    # Automatically configures ActionMailer to support the Amazon SES and SESV2
-    # delivery methods.
+    # @api private
     class Railtie < Rails::Railtie
       ActiveSupport.on_load(:action_mailer) do
         add_delivery_method :ses, SES::Mailer

--- a/lib/aws/action_mailer/railtie.rb
+++ b/lib/aws/action_mailer/railtie.rb
@@ -5,11 +5,9 @@ module Aws
     # Automatically configures ActionMailer to support the Amazon SES and SESV2
     # delivery methods.
     class Railtie < Rails::Railtie
-      config.before_initialize do
-        ActiveSupport.on_load(:action_mailer) do
-          add_delivery_method :ses, SES::Mailer
-          add_delivery_method :ses_v2, SESV2::Mailer
-        end
+      ActiveSupport.on_load(:action_mailer) do
+        add_delivery_method :ses, SES::Mailer
+        add_delivery_method :ses_v2, SESV2::Mailer
       end
     end
   end

--- a/spec/aws/action_mailer/railtie_spec.rb
+++ b/spec/aws/action_mailer/railtie_spec.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+module Aws
+  module ActionMailer
+    describe Railtie do
+      it 'adds SES and SESV2 delivery methods' do
+        expect(::ActionMailer::Base.delivery_methods).to include(:ses, :ses_v2)
+      end
+
+      it 'can be configured using config.action_mailer.<mailer>_settings' do
+        expect(::ActionMailer::Base.ses_settings).to eq({ region: 'peccy' })
+        expect(::ActionMailer::Base.ses_v2_settings).to eq({ region: 'peccy_v2' })
+      end
+    end
+  end
+end

--- a/spec/dummy/config/application.rb
+++ b/spec/dummy/config/application.rb
@@ -12,5 +12,8 @@ module Dummy
     config.load_defaults Rails::VERSION::STRING.to_f
     config.eager_load = true
     config.secret_key_base = 'secret'
+
+    config.action_mailer.ses_settings = { region: 'peccy' }
+    config.action_mailer.ses_v2_settings = { region: 'peccy_v2' }
   end
 end


### PR DESCRIPTION
Fix usage of `config.action_mailer.<mailer>_settings` by adding delivery method after initializing railties.