### PR TITLE
Forward :list_management_options to SES v2 SendEmail

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 Unreleased Changes
 ------------------
 
+* Feature - SESV2: forward `:list_management_options` from delivery settings to `SendEmail` as the typed `ListManagementOptions` parameter, enabling SES subscription management. Set via `config.action_mailer.ses_v2_settings` or per-mailer `delivery_method_options`.
+
 1.1.0 (2026-03-31)
 ------------------
 

--- a/lib/aws/action_mailer/ses_v2/mailer.rb
+++ b/lib/aws/action_mailer/ses_v2/mailer.rb
@@ -26,9 +26,18 @@ module Aws
         #   You may pass `:sesv2_client` with a preconstructed {Aws::SESV2::Client} to reuse
         #   an existing instance (e.g. to avoid credential resolution on every delivery).
         #   When provided, the injected client is used and all other options are ignored.
+        #
+        #   Pass `:list_management_options` (a {Types::ListManagementOptions} hash) to enable
+        #   SES subscription management — typically supplied via ActionMailer's
+        #   `delivery_method_options` so it can be set per-mailer or per-message:
+        #
+        #     default delivery_method_options: {
+        #       list_management_options: { contact_list_name: "...", topic_name: "..." }
+        #     }
         def initialize(settings = {})
           @settings = settings
           client_settings = settings.dup
+          @list_management_options = client_settings.delete(:list_management_options)
           @client = client_settings.delete(:sesv2_client) || Aws::SESV2::Client.new(client_settings)
 
           update_user_agent
@@ -43,6 +52,7 @@ module Aws
             cc_addresses: message.cc,
             bcc_addresses: message.bcc
           }
+          params[:list_management_options] = @list_management_options if @list_management_options
 
           @client.send_email(params).tap do |response|
             message.header[:ses_message_id] = response.message_id

--- a/spec/aws/action_mailer/ses_v2/mailer_spec.rb
+++ b/spec/aws/action_mailer/ses_v2/mailer_spec.rb
@@ -100,6 +100,38 @@ module Aws
             expect(raw).to include('X-SES-CONFIGURATION-SET: TestConfigSet')
             expect(raw).to include('X-SES-LIST-MANAGEMENT-OPTIONS: contactListName; topic=topic')
           end
+
+          context 'with :list_management_options in settings' do
+            let(:list_management_options) do
+              { contact_list_name: 'MarketingList', topic_name: 'Promos' }
+            end
+            let(:client_options) do
+              {
+                stub_responses: { send_email: { message_id: ses_message_id } },
+                list_management_options: list_management_options
+              }
+            end
+
+            it 'passes list_management_options to SendEmail as a typed parameter' do
+              mailer_data = mailer.deliver!(sample_message).context.params
+              expect(mailer_data[:list_management_options]).to eq(list_management_options)
+            end
+
+            it 'does not forward :list_management_options to the SES client constructor' do
+              captured = nil
+              allow(Aws::SESV2::Client).to receive(:new).and_wrap_original do |original, settings = {}|
+                captured = settings
+                original.call(stub_responses: { send_email: { message_id: ses_message_id } })
+              end
+              Mailer.new(client_options)
+              expect(captured).not_to have_key(:list_management_options)
+            end
+          end
+
+          it 'omits list_management_options when not configured' do
+            mailer_data = mailer.deliver!(sample_message).context.params
+            expect(mailer_data).not_to have_key(:list_management_options)
+          end
         end
       end
     end


### PR DESCRIPTION
Adds support for passing ListManagementOptions to SendEmail as a typed API parameter, enabling SES subscription management. The value flows through delivery settings, so mailers can set it via ActionMailer's delivery_method_options:

    default delivery_method_options: {
      list_management_options: {
        contact_list_name: "MarketingList",
        topic_name:        "Promos"
      }
    }

Previously the only path to enable subscription management with this gem was via SMTP (which honors X-SES-LIST-MANAGEMENT-OPTIONS). The SES v2 SendEmail API does not read that header from raw MIME — it requires the typed parameter instead.

*Issue #, if available:*

*Description of changes:*

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license.
